### PR TITLE
Add INR to USD currency conversion service

### DIFF
--- a/src/main/java/com/water/water/controller/CurrencyConversionController.java
+++ b/src/main/java/com/water/water/controller/CurrencyConversionController.java
@@ -1,0 +1,21 @@
+package com.water.water.controller;
+
+import com.water.water.service.CurrencyConversionService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/convert")
+public class CurrencyConversionController {
+
+    @Autowired
+    private CurrencyConversionService currencyConversionService;
+
+    @GetMapping("/inr-to-usd")
+    public double convertINRtoUSD(@RequestParam double amountInINR) {
+        return currencyConversionService.convertINRtoUSD(amountInINR);
+    }
+}

--- a/src/main/java/com/water/water/service/CurrencyConversionService.java
+++ b/src/main/java/com/water/water/service/CurrencyConversionService.java
@@ -1,0 +1,13 @@
+package com.water.water.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class CurrencyConversionService {
+
+    private static final double INR_TO_USD_RATE = 80.0;
+
+    public double convertINRtoUSD(double amountInINR) {
+        return amountInINR / INR_TO_USD_RATE;
+    }
+}

--- a/src/test/java/com/water/water/service/CurrencyConversionServiceTest.java
+++ b/src/test/java/com/water/water/service/CurrencyConversionServiceTest.java
@@ -1,0 +1,23 @@
+package com.water.water.service;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CurrencyConversionServiceTest {
+
+    @InjectMocks
+    private CurrencyConversionService currencyConversionService;
+
+    @Test
+    public void testConvertINRtoUSD() {
+        double amountInINR = 160.0;
+        double expectedAmountInUSD = 2.0; // 160 / 80 = 2
+        double actualAmountInUSD = currencyConversionService.convertINRtoUSD(amountInINR);
+        assertEquals(expectedAmountInUSD, actualAmountInUSD, 0.001);
+    }
+}


### PR DESCRIPTION
This commit introduces a new service to convert Indian Rupees (INR) to US Dollars (USD).

Key changes:
- Added `CurrencyConversionService` with a method `convertINRtoUSD` that takes an INR amount and returns the USD equivalent using a fixed rate of 1 USD = 80 INR.
- Added `CurrencyConversionController` with a REST endpoint `/convert/inr-to-usd` to expose this service.
- Added a unit test for `CurrencyConversionService` to verify the conversion logic.